### PR TITLE
add pymonocypher package for secure boot signing

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -56,6 +56,7 @@
 
         (pkgs.python3.withPackages (p: [
           (p.callPackage ./nix/packages/empy {})
+          (p.callPackage ./nix/packages/pymonocypher {})
           p.pexpect
           p.setuptools
           p.future

--- a/nix/packages/pymonocypher/default.nix
+++ b/nix/packages/pymonocypher/default.nix
@@ -1,0 +1,24 @@
+# Pinned to 3.1.3.2 to match the version required by the signing scripts.
+{ lib, fetchPypi, buildPythonPackage, setuptools }:
+
+buildPythonPackage rec {
+  pname = "pymonocypher";
+  version = "3.1.3.2";
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-s+ZAbWQjCoMnjLi+mP6wjCPfaowAzzwxccWydXte2ek=";
+  };
+
+  nativeBuildInputs = [ setuptools ];
+
+  pythonImportsCheck = [ "monocypher" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/jetperch/pymonocypher";
+    description = "Python bindings for Monocypher crypto library";
+    license = licenses.bsd2;
+    maintainers = [ ];
+  };
+}


### PR DESCRIPTION
Adds the pymonocypher Python package pinned to the version required by ArduPilot to support secure boot signing.